### PR TITLE
genrl_swarm/game/game_manager.py: refactor run_game()

### DIFF
--- a/src/genrl_swarm/game/game_manager.py
+++ b/src/genrl_swarm/game/game_manager.py
@@ -137,17 +137,15 @@ class GameManager(abc.ABC): #TODO: Make this use enum
         world_state_pruners, game_tree_brancher = self.aggregate_game_state_methods()
         self.state._init_game(self.data_manager.get_round_data(), agent_keys=self.agent_ids, world_state_pruners=world_state_pruners, game_tree_brancher=game_tree_brancher) # Prepare game trees within the game state for the initial round's batch of data
         # Loop through rounds until end of the game is hit
-        while not self.end_of_game():
-            try:
+        try:
+            while not self.end_of_game():
                 get_logger().info(f"Starting round: {self.state.round}/{getattr(self, 'max_round', None)}.")
                 self.run_game_round() # Loops through stages until end of round signal is received
-            except:
-                get_logger().exception("Exception occurred during game run.", stack_info=True)
-                break
-
-        self._hook_after_game()
-        self.trainer.cleanup()        
-
+        except:
+            get_logger().exception("Exception occurred during game run.", stack_info=True)
+        finally:
+            self._hook_after_game()
+            self.trainer.cleanup()
 
 class DefaultGameManagerMixin:
     """


### PR DESCRIPTION
the current code can prevent from the proper cleanup to take place, because is case of user running the genrl is out of the threads/resoures, there are cases of this:
```
Traceback (most recent call last):
  File "/home/anon/rl-swarm/genrl-swarm/src/genrl_swarm/game/game_manager.py", line 143, in run_game
    self.run_game_round() # Loops through stages until end of round signal is received
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/anon/rl-swarm/genrl-swarm/src/genrl_swarm/game/game_manager.py", line 119, in run_game_round
    swarm_payloads = self.communication.all_gather_object(self.state.get_latest_communication()[self.rank])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anon/rl-swarm/genrl-swarm/src/genrl_swarm/communication/hivemind/hivemind_backend.py", line 97, in all_gather_object
    self.dht.store(
  File "/home/anon/rl-swarm/.venv/lib/python3.12/site-packages/hivemind/dht/dht.py", line 220, in store
    return future if return_future else future.result()
                                        ^^^^^^^^^^^^^^^
  File "/home/anon/rl-swarm/.venv/lib/python3.12/site-packages/hivemind/utils/mpfuture.py", line 254, in result
    return super().result(timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 451, in result
    self._condition.wait(timeout)
  File "/usr/lib/python3.12/threading.py", line 355, in wait
    waiter.acquire()
```
which stucks the process and needs manual preemption. Adding a `finally` block and refactoring the `while` loop should help.